### PR TITLE
fix typo matirx -> matrix in typstfun.sty

### DIFF
--- a/typstfun.sty
+++ b/typstfun.sty
@@ -73,18 +73,18 @@
 }
 
 \propConstFromKeyval\c@typstfun@math@env@prop{
-   Bmatirx = mat
-  ,Vmatirx = mat
+   Bmatrix = mat
+  ,Vmatrix = mat
   ,align = equation
   ,array = mat
-  ,bmatirx = mat
+  ,bmatrix = mat
   ,cases = cases
   ,displaymath = equation
   ,equation = equation
   ,math = math
   ,matrix = mat
-  ,pmatirx = mat
-  ,vmatirx = mat
+  ,pmatrix = mat
+  ,vmatrix = mat
 }
 
 \propConstFromKeyval\c@typstfun@math@cmd@prop{


### PR DESCRIPTION
Hi, I found this repo via google and noticed this typo, hope it helps. Best wishes